### PR TITLE
Fixed Firefox scroll on OSX

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "vsicons.presets.angular": true
+}

--- a/lib/components/fullpage.js
+++ b/lib/components/fullpage.js
@@ -9,12 +9,13 @@ const { KEY_IDX, GET_BODY, GET_BROWSER, GET_OS} = renderUtils;
 var touchArr = [];
 var latestTouch
 var needsConversion = null;
+var needsConversionOSX = null;
 
 class Fullpage extends React.Component {
   constructor(props) {
     super(props);
 
-    let slideChildren = getSlideCount(this.props.children);    
+    let slideChildren = getSlideCount(this.props.children);
 
     this.state = {
       name: 'Fullpage',
@@ -49,9 +50,11 @@ class Fullpage extends React.Component {
     var b = GET_BROWSER();
     var os = GET_OS();
     if (b === 'Firefox' && os === 'WINDOWS') {
-      needsConversion = true;      
+      needsConversion = true;
     }
-
+    if (b === 'Firefox' && os === 'OSX') {
+      needsConversionOSX = true;
+    }
     //initialize slides
     this.onResize();
   }
@@ -153,7 +156,7 @@ class Fullpage extends React.Component {
     var s = this.state;
     const touchEnd = e.changedTouches[0].clientY;
     const touchStart = s.touchStart;
-    const sensitivity = s.touchSensitivity;    
+    const sensitivity = s.touchSensitivity;
 
     //prevent standard taps creating false positives;
     if (latestTouch !== touchEnd) {
@@ -180,7 +183,7 @@ class Fullpage extends React.Component {
     this.scrollToSlide(this.state.activeSlide + 1);
   }
 
-  onScroll(e) {    
+  onScroll(e) {
     e.preventDefault();
     var s = this.state;
 
@@ -190,11 +193,15 @@ class Fullpage extends React.Component {
 
     var meas = needsConversion ? -e.deltaY : (e.wheelDelta || -e.deltaY || e.detail);
     //windows firefox produces very low wheel activity so we have to multiply it
-    if (needsConversion) { 
+    if (needsConversion) {
       meas = meas * 3;
     }
-    
-    const scrollDown =  meas < s.downThreshold;    
+
+    if (needsConversionOSX) {
+      meas = meas * 40;
+    }
+
+    const scrollDown =  meas < s.downThreshold;
     const scrollUp = !scrollDown && ( meas > s.upThreshold );
 
     if (!scrollDown && !scrollUp) {

--- a/lib/utils/renderUtils.js
+++ b/lib/utils/renderUtils.js
@@ -66,7 +66,11 @@ const GET_OS = () => {
 
     if (code.indexOf('win') >= 0) {
       OS = 'WINDOWS';
-    }  
+    }
+
+    if (code.indexOf('macintel') >= 0) {
+      OS = 'OSX';
+    }
   }
 
   return OS;
@@ -81,8 +85,8 @@ const GET_BROWSER = () => {
 
 const GET_BODY = () => {
   if (!BODY) {
-    BROWSER = browser();    
-    BODY = ELEMENT_BROWSERS[BROWSER] ? document.documentElement : document.body;    
+    BROWSER = browser();
+    BODY = ELEMENT_BROWSERS[BROWSER] ? document.documentElement : document.body;
   }
 
   return BODY;


### PR DESCRIPTION
Add check for OSX and Firefox. For correct scroll on OSX deltaY need multiplier 40.