### PR TITLE
Fix for documentElement not scrolling UI

### DIFF
--- a/lib/components/fullpage.js
+++ b/lib/components/fullpage.js
@@ -551,9 +551,9 @@ function determineVerticalRoot() {
   const { name, version, os } = utils.detectBrowser(agent);
   const [ major, minor, patch ] = version.split('.');
 
-  // firefox/canary + newer chrome
-  if (name === 'firefox' || name === 'chrome' && Number(major) > 60) {
-    return (typeof document.body.scrollTop !== 'undefined') ? document.body : document.documentElement;
+  // Firefox
+  if (name === 'firefox') {
+    return document.documentElement;
   }
 
   // safari, old chrome, etc

--- a/lib/components/fullpage.js
+++ b/lib/components/fullpage.js
@@ -551,14 +551,9 @@ function determineVerticalRoot() {
   const { name, version, os } = utils.detectBrowser(agent);
   const [ major, minor, patch ] = version.split('.');
 
-  // firefox
-  if (name === 'firefox') {
-    return document.documentElement;
-  }
-
-  // canary + newer chrome
-  if (name === 'chrome' && Number(major) > 60) {
-    return document.documentElement;
+  // firefox/canary + newer chrome
+  if (name === 'firefox' || name === 'chrome' && Number(major) > 60) {
+    return (typeof document.body.scrollTop !== 'undefined') ? document.body : document.documentElement;
   }
 
   // safari, old chrome, etc

--- a/lib/utils/scrollTo.js
+++ b/lib/utils/scrollTo.js
@@ -1,14 +1,26 @@
+
+import { detectBrowser } from './index.js';
+
 function scrollTo(element, elementBoundary, to, duration, callback) {
-  const start = element[elementBoundary],
-    change = to - start,
-    increment = 10;
+  const { name, version } = detectBrowser(navigator && navigator.userAgent);
+  const [ major ] = version.split('.');
+  const newChrome = (name === 'chrome' && Number(major) > 60);
+  const start = newChrome ? window.scrollY : element[elementBoundary];
+  const change = to - start;
+  const increment = 10;
 
   let currentTime = 0;
   let globalId = requestAnimationFrame(repeatOften);
   function repeatOften() {
     currentTime += increment;
     let val = easeInOutQuad(currentTime, start, change, duration);
-    element[elementBoundary] = val;
+
+    // canary + newer chrome
+    if (newChrome) {
+      window.scrollTo(0, val);
+    } else {
+      element[elementBoundary] = val;
+    }
 
     if (currentTime >= duration) {
       cancelAnimationFrame(globalId);


### PR DESCRIPTION
Fix for documentElement not scrolling UI in newer Chrome and Firefox builds. Detect if body.scrollTop exists, if so use body for scrolling, else use documentElement.