### PR TITLE
boilerplate-typo - Fixed fullPageOptions typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const slides = [
   <HorizontalSlider {...horizontalSliderProps}></HorizontalSlider>
   <Slide> Slide 3 </Slide>
 ];
-fullpageOptions.slides = slides;
+fullPageOptions.slides = slides;
 
 <Fullpage {...fullPageOptions} />
 


### PR DESCRIPTION
Fixed a minor type in the boilerplate example that caused the example to throw an error.