### PR TITLE
add ie to list of browsers to use documentElement

### DIFF
--- a/lib/components/Fullpage.js
+++ b/lib/components/Fullpage.js
@@ -568,7 +568,8 @@ function determineVerticalRoot() {
     'firefox',
     'chrome',
     'ios', // iPad (chrome devtools)
-    'crios' // chrome ios (chrome devtools)
+    'crios', // chrome ios (chrome devtools)
+    'ie'
   ]);
 
   // Some platforms conflict with the devtools when it comes to supporting document.body


### PR DESCRIPTION
IE 11 can't run scrollTop on body. This change adds ie to the list of browsers that uses documentElement instead.